### PR TITLE
Issue Forms: Fix Typos, Remove Default Titles, Automatic Labels(?)

### DIFF
--- a/.github/ISSUE_TEMPLATE/ability-draft.yaml
+++ b/.github/ISSUE_TEMPLATE/ability-draft.yaml
@@ -1,4 +1,4 @@
-name: Abillity Draft
+name: Ability Draft
 description: A problem in the Ability Draft game mode
 
 title: "Enter a short summary here!"

--- a/.github/ISSUE_TEMPLATE/ability-draft.yaml
+++ b/.github/ISSUE_TEMPLATE/ability-draft.yaml
@@ -1,7 +1,6 @@
 name: Ability Draft
 description: A problem in the Ability Draft game mode
 
-title: "Enter a short summary here!"
 labels: ["ability-draft"]
 
 body:

--- a/.github/ISSUE_TEMPLATE/ability.yaml
+++ b/.github/ISSUE_TEMPLATE/ability.yaml
@@ -1,4 +1,4 @@
-name: Abillity Bug
+name: Ability Bug
 description: An ability behaves in a way it probably shouldn't!
 
 title: "Enter a short summary here!"

--- a/.github/ISSUE_TEMPLATE/ability.yaml
+++ b/.github/ISSUE_TEMPLATE/ability.yaml
@@ -1,7 +1,6 @@
 name: Ability Bug
 description: An ability behaves in a way it probably shouldn't!
 
-title: "Enter a short summary here!"
 labels: ["ability"]
 
 body:

--- a/.github/ISSUE_TEMPLATE/cosmetic.yaml
+++ b/.github/ISSUE_TEMPLATE/cosmetic.yaml
@@ -1,7 +1,6 @@
 name: Cosmetic Bug
 description: A cosmetic item is missing particles, positioned wrong, etc.
 
-title: "Enter a short summary here!"
 labels: ["cosmetic"]
 
 body:

--- a/.github/ISSUE_TEMPLATE/cosmetic.yaml
+++ b/.github/ISSUE_TEMPLATE/cosmetic.yaml
@@ -1,5 +1,5 @@
 name: Cosmetic Bug
-description: A costmetic item is missing particles, positioned wrong, etc.
+description: A cosmetic item is missing particles, positioned wrong, etc.
 
 title: "Enter a short summary here!"
 labels: ["cosmetic"]

--- a/.github/ISSUE_TEMPLATE/item.yaml
+++ b/.github/ISSUE_TEMPLATE/item.yaml
@@ -1,7 +1,6 @@
 name: Item Bug
 description: An item behaves in a way it probably shouldn't!
 
-title: "Enter a short summary here!"
 labels: ["item"]
 
 body:

--- a/.github/ISSUE_TEMPLATE/other.yaml
+++ b/.github/ISSUE_TEMPLATE/other.yaml
@@ -1,8 +1,6 @@
 name: Other
 description: The other templates don't fit your problem?
 
-title: "Enter a short summary here!"
-
 body:
   - type: textarea
     id: desc

--- a/.github/ISSUE_TEMPLATE/tooltips.yaml
+++ b/.github/ISSUE_TEMPLATE/tooltips.yaml
@@ -1,7 +1,6 @@
 name: Incorrect tooltip
 description: A tooltip is wrong in some way - typos, spell amp does not affect damage numbers, talent changes not showing, etc.
 
-title: "Enter a short summary here!"
 labels: ["tooltip"]
 
 body:


### PR DESCRIPTION
- Automatic labelling was already added in the last PR but there is a manual step required before they are added, which is to add said labels in the [label settings](https://github.com/jeffhill/Dota2/labels) (case sensitive)
  - `ability`, `ability-draft`, `cosmetic`, `item`, and `tooltip`
- Fixes typos in issue forms
- Removes default titles from the issue forms, forcing the submitters to add one